### PR TITLE
docs: add Tura to AI coding assistants

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,7 @@
 
 - [void](https://github.com/voideditor/void) - 开源的 `Cursor` 替代品。
 - [cline](https://github.com/cline/cline) - 一个开源的 `AI` 编程 `VSCode` 插件。
+- [Tura](https://github.com/Tura-AI/tura) - 本地优先的开源 `AI` 编程助手，提供 `CLI`、`TUI`、桌面和 `Web` 界面，支持多会话并发与本地模型。
 
 **[⬆️ 回到顶部 ](#github-gitee-优秀的开源项目)**
 


### PR DESCRIPTION
## 说明

将 [Tura](https://github.com/Tura-AI/tura) 添加到“AI 项目 → 编程助手”分类。Tura 是本地优先的开源 AI 编程助手，提供 CLI、TUI、桌面和 Web 界面，支持多会话并发、持久化会话以及本地模型或 OpenAI 兼容 API。

## 检查

- 已确认 Tura 与现有 `void`、`cline` 条目属于同一分类。
- 已搜索仓库 Issues 和 README，未发现现有 Tura 条目或提交。
- `git diff --check` 通过。

披露：我与 Tura 项目有关联。